### PR TITLE
Changed h2 heading: 1-min CEFI -> brief overview

### DIFF
--- a/overview.html
+++ b/overview.html
@@ -22,7 +22,7 @@
   </div>
 </div>
 
-<h2 class="headingCenter">1 minute CEFI</h2>
+<h2 class="headingCenter">CEFI: a brief overview</h2>
 <p>
   The goal of the Changing Ecosystem and Fisheries Initiative (CEFI) is to provide 
   information about past and future conditions for US coastal regions 🌎🌊🐟.


### PR DESCRIPTION
A very minor edit to the landing page...

I've fielded some confusion regarding the "1 minute CEFI" heading, with people thinking "1 minute" refers to either the temporal or spatial resolution of the regional models.  This PR suggests a more straightforward title.